### PR TITLE
Add edge DOFs and Maxwell assembly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,13 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 find_package(Eigen3 3.4 REQUIRED)
 
-add_subdirectory(src)
+option(VECTOREM_BUILD_SCALAR "Build scalar prototype" ON)
+option(VECTOREM_BUILD_VECTOR "Build vector Maxwell path" ON)
 
-add_test(NAME smoke_scalar_demo COMMAND vectorem_scalar_demo ${PROJECT_SOURCE_DIR}/examples/cube_cavity.msh 1)
-set_tests_properties(smoke_scalar_demo PROPERTIES LABELS smoke)
+add_subdirectory(src)
+add_subdirectory(tests)
+
+if (VECTOREM_BUILD_SCALAR)
+  add_test(NAME smoke_scalar_demo COMMAND vectorem_scalar_demo ${PROJECT_SOURCE_DIR}/examples/cube_cavity.msh 1)
+  set_tests_properties(smoke_scalar_demo PROPERTIES LABELS smoke)
+endif()

--- a/include/vectorem/bc.hpp
+++ b/include/vectorem/bc.hpp
@@ -8,8 +8,10 @@ namespace vectorem {
 
 struct BC {
   std::unordered_set<int> dirichlet_nodes;
+  std::unordered_set<int> dirichlet_edges;
 };
 
 BC build_scalar_pec(const Mesh &mesh, int pec_tag);
+BC build_edge_pec(const Mesh &mesh, int pec_tag);
 
 } // namespace vectorem

--- a/include/vectorem/edge_basis.hpp
+++ b/include/vectorem/edge_basis.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <array>
+#include <Eigen/Core>
+
+namespace vectorem {
+
+Eigen::Matrix<double, 6, 3>
+whitney_edge_curls(const std::array<Eigen::Vector3d, 4> &v);
+
+Eigen::Matrix<double, 6, 6>
+whitney_curl_curl_matrix(const std::array<Eigen::Vector3d, 4> &v);
+
+Eigen::Matrix<double, 6, 6>
+whitney_mass_matrix(const std::array<Eigen::Vector3d, 4> &v);
+
+}

--- a/include/vectorem/maxwell.hpp
+++ b/include/vectorem/maxwell.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <Eigen/Sparse>
+#include <complex>
+
+#include "vectorem/bc.hpp"
+#include "vectorem/mesh.hpp"
+
+namespace vectorem {
+
+using VecC = Eigen::VectorXcd;
+using SpMatC = Eigen::SparseMatrix<std::complex<double>>;
+
+struct MaxwellParams {
+  double omega = 0.0;
+  double eps_r = 1.0;
+  double mu_r = 1.0;
+};
+
+struct MaxwellAssembly {
+  SpMatC A;
+  VecC b;
+};
+
+MaxwellAssembly assemble_maxwell(const Mesh &mesh,
+                                 const MaxwellParams &p,
+                                 const BC &bc);
+
+} // namespace vectorem

--- a/include/vectorem/mesh.hpp
+++ b/include/vectorem/mesh.hpp
@@ -15,6 +15,11 @@ struct Node {
   Eigen::Vector3d xyz;
 };
 
+struct Edge {
+  std::int64_t n0;
+  std::int64_t n1;
+};
+
 enum class ElemType : int {
   Tri3 = 2, // surface triangle
   Tet4 = 4  // volume tetrahedron
@@ -25,6 +30,8 @@ struct Element {
   ElemType type;
   std::array<std::int64_t, 4> conn{}; // Tet4 uses first 4 entries
   int phys = 0;                       // physical tag (BC/material)
+  std::array<int, 6> edges{};         // global edge indices
+  std::array<int, 6> edge_orient{};   // +1 if same orientation as global
 };
 
 struct Mesh {
@@ -32,9 +39,18 @@ struct Mesh {
   std::vector<Element> tets;
   std::vector<Element> tris; // boundary faces
   // maps for quick lookup
+  std::vector<Edge> edges; // global edges (n0 < n1)
+  std::unordered_map<std::uint64_t, int> edgeIndex; // key -> edge index
   std::unordered_map<std::int64_t, int> nodeIndex;
 };
 
 Mesh load_gmsh_v2(const std::string &path);
+
+inline std::uint64_t make_edge_key(std::int64_t a, std::int64_t b) {
+  if (a > b)
+    std::swap(a, b);
+  return (static_cast<std::uint64_t>(a) << 32) ^
+         static_cast<std::uint64_t>(b);
+}
 
 } // namespace vectorem

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,15 +1,23 @@
 add_library(vectorem
   mesh_gmsh.cpp
-  fem_scalar.cpp
   solver.cpp
   bc.cpp
 )
+
+if (VECTOREM_BUILD_SCALAR)
+  target_sources(vectorem PRIVATE fem_scalar.cpp)
+endif()
+
+if (VECTOREM_BUILD_VECTOR)
+  target_sources(vectorem PRIVATE edge_basis.cpp assemble_maxwell.cpp)
+endif()
 
 target_include_directories(vectorem PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
 target_link_libraries(vectorem PUBLIC Eigen3::Eigen)
 
-add_executable(vectorem_scalar_demo main_scalar_demo.cpp)
-
-target_link_libraries(vectorem_scalar_demo PRIVATE vectorem)
+if (VECTOREM_BUILD_SCALAR)
+  add_executable(vectorem_scalar_demo main_scalar_demo.cpp)
+  target_link_libraries(vectorem_scalar_demo PRIVATE vectorem)
+endif()
 

--- a/src/assemble_maxwell.cpp
+++ b/src/assemble_maxwell.cpp
@@ -1,0 +1,56 @@
+#include "vectorem/maxwell.hpp"
+#include "vectorem/edge_basis.hpp"
+
+#include <Eigen/SparseCore>
+#include <vector>
+
+namespace vectorem {
+
+MaxwellAssembly assemble_maxwell(const Mesh &mesh,
+                                 const MaxwellParams &p,
+                                 const BC &bc) {
+  const int m = static_cast<int>(mesh.edges.size());
+  MaxwellAssembly asmbl;
+  asmbl.A.resize(m, m);
+  asmbl.b = VecC::Zero(m);
+
+  using T = Eigen::Triplet<std::complex<double>>;
+  std::vector<T> trips;
+
+  for (const auto &tet : mesh.tets) {
+    std::array<Eigen::Vector3d, 4> X;
+    for (int i = 0; i < 4; ++i) {
+      int idx = mesh.nodeIndex.at(tet.conn[i]);
+      X[i] = mesh.nodes[idx].xyz;
+    }
+    auto Kloc = whitney_curl_curl_matrix(X);
+    auto Mloc = whitney_mass_matrix(X);
+    for (int i = 0; i < 6; ++i) {
+      int gi = tet.edges[i];
+      int si = tet.edge_orient[i];
+      for (int j = 0; j < 6; ++j) {
+        int gj = tet.edges[j];
+        int sj = tet.edge_orient[j];
+        std::complex<double> val =
+            (Kloc(i, j) / p.mu_r) -
+            (p.omega * p.omega * p.eps_r * Mloc(i, j));
+        val *= static_cast<double>(si * sj);
+        trips.emplace_back(gi, gj, val);
+      }
+    }
+  }
+  asmbl.A.setFromTriplets(trips.begin(), trips.end());
+
+  for (int e : bc.dirichlet_edges) {
+    for (Eigen::SparseMatrix<std::complex<double>>::InnerIterator it(asmbl.A, e);
+         it; ++it) {
+      it.valueRef() = (it.row() == e && it.col() == e)
+                          ? std::complex<double>(1.0, 0.0)
+                          : std::complex<double>(0.0, 0.0);
+    }
+    asmbl.b(e) = 0.0;
+  }
+  return asmbl;
+}
+
+} // namespace vectorem

--- a/src/bc.cpp
+++ b/src/bc.cpp
@@ -19,4 +19,16 @@ BC build_scalar_pec(const Mesh &mesh, int pec_tag) {
   return bc;
 }
 
+BC build_edge_pec(const Mesh &mesh, int pec_tag) {
+  BC bc;
+  for (const auto &tri : mesh.tris) {
+    if (tri.phys == pec_tag) {
+      for (int k = 0; k < 3; ++k) {
+        bc.dirichlet_edges.insert(tri.edges[k]);
+      }
+    }
+  }
+  return bc;
+}
+
 } // namespace vectorem

--- a/src/edge_basis.cpp
+++ b/src/edge_basis.cpp
@@ -1,0 +1,89 @@
+#include "vectorem/edge_basis.hpp"
+
+#include <array>
+#include <Eigen/Dense>
+
+namespace vectorem {
+namespace {
+const std::array<std::array<int, 2>, 6> edge_pairs = {std::array<int,2>{0,1},
+                                                     std::array<int,2>{0,2},
+                                                     std::array<int,2>{0,3},
+                                                     std::array<int,2>{1,2},
+                                                     std::array<int,2>{1,3},
+                                                     std::array<int,2>{2,3}};
+
+void gradients_and_volume(const std::array<Eigen::Vector3d, 4> &v,
+                          std::array<Eigen::Vector3d, 4> &g, double &V) {
+  Eigen::Matrix3d B;
+  B.col(0) = v[0] - v[3];
+  B.col(1) = v[1] - v[3];
+  B.col(2) = v[2] - v[3];
+  Eigen::Matrix3d BinvT = B.inverse().transpose();
+  g[0] = BinvT.col(0);
+  g[1] = BinvT.col(1);
+  g[2] = BinvT.col(2);
+  g[3] = -g[0] - g[1] - g[2];
+  V = std::abs(B.determinant()) / 6.0;
+}
+
+double lambda_int(int i, int j, double V) {
+  return (i == j) ? V / 10.0 : V / 20.0;
+}
+} // namespace
+
+Eigen::Matrix<double, 6, 3>
+whitney_edge_curls(const std::array<Eigen::Vector3d, 4> &v) {
+  std::array<Eigen::Vector3d, 4> g;
+  double V;
+  gradients_and_volume(v, g, V);
+  Eigen::Matrix<double, 6, 3> curls;
+  for (int i = 0; i < 6; ++i) {
+    int a = edge_pairs[i][0];
+    int b = edge_pairs[i][1];
+    curls.row(i) = 2.0 * g[a].cross(g[b]);
+  }
+  return curls;
+}
+
+Eigen::Matrix<double, 6, 6>
+whitney_curl_curl_matrix(const std::array<Eigen::Vector3d, 4> &v) {
+  std::array<Eigen::Vector3d, 4> g;
+  double V;
+  gradients_and_volume(v, g, V);
+  Eigen::Matrix<double, 6, 3> curls;
+  for (int i = 0; i < 6; ++i) {
+    int a = edge_pairs[i][0];
+    int b = edge_pairs[i][1];
+    curls.row(i) = 2.0 * g[a].cross(g[b]);
+  }
+  Eigen::Matrix<double, 6, 6> K;
+  for (int i = 0; i < 6; ++i)
+    for (int j = 0; j < 6; ++j)
+      K(i, j) = V * curls.row(i).dot(curls.row(j));
+  return K;
+}
+
+Eigen::Matrix<double, 6, 6>
+whitney_mass_matrix(const std::array<Eigen::Vector3d, 4> &v) {
+  std::array<Eigen::Vector3d, 4> g;
+  double V;
+  gradients_and_volume(v, g, V);
+  Eigen::Matrix<double, 6, 6> M;
+  for (int i = 0; i < 6; ++i) {
+    int a = edge_pairs[i][0];
+    int b = edge_pairs[i][1];
+    for (int j = 0; j < 6; ++j) {
+      int c = edge_pairs[j][0];
+      int d = edge_pairs[j][1];
+      double term = 0.0;
+      term += g[b].dot(g[d]) * lambda_int(a, c, V);
+      term -= g[b].dot(g[c]) * lambda_int(a, d, V);
+      term -= g[a].dot(g[d]) * lambda_int(b, c, V);
+      term += g[a].dot(g[c]) * lambda_int(b, d, V);
+      M(i, j) = term;
+    }
+  }
+  return M;
+}
+
+} // namespace vectorem

--- a/src/mesh_gmsh.cpp
+++ b/src/mesh_gmsh.cpp
@@ -1,10 +1,14 @@
 #include "vectorem/mesh.hpp"
 
+#include <array>
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
 
 namespace vectorem {
+namespace {
+void build_edges(Mesh &mesh);
+}
 
 Mesh load_gmsh_v2(const std::string &path) {
   std::ifstream in(path);
@@ -60,7 +64,55 @@ Mesh load_gmsh_v2(const std::string &path) {
       std::getline(in, line); // "$EndElements"
     }
   }
+  build_edges(mesh);
   return mesh;
 }
 
+namespace {
+void build_edges(Mesh &mesh) {
+  const std::array<std::array<int, 2>, 6> tet_pairs = {std::array<int,2>{0,1},
+                                                       std::array<int,2>{0,2},
+                                                       std::array<int,2>{0,3},
+                                                       std::array<int,2>{1,2},
+                                                       std::array<int,2>{1,3},
+                                                       std::array<int,2>{2,3}};
+  const std::array<std::array<int, 2>, 3> tri_pairs = {std::array<int,2>{0,1},
+                                                       std::array<int,2>{1,2},
+                                                       std::array<int,2>{2,0}};
+  for (auto &tet : mesh.tets) {
+    for (int e = 0; e < 6; ++e) {
+      auto a = tet.conn[tet_pairs[e][0]];
+      auto b = tet.conn[tet_pairs[e][1]];
+      int sign = (a < b) ? 1 : -1;
+      std::uint64_t key = make_edge_key(a, b);
+      auto it = mesh.edgeIndex.find(key);
+      if (it == mesh.edgeIndex.end()) {
+        int idx = static_cast<int>(mesh.edges.size());
+        mesh.edgeIndex[key] = idx;
+        mesh.edges.push_back(Edge{std::min(a, b), std::max(a, b)});
+        it = mesh.edgeIndex.find(key);
+      }
+      tet.edges[e] = it->second;
+      tet.edge_orient[e] = sign;
+    }
+  }
+  for (auto &tri : mesh.tris) {
+    for (int e = 0; e < 3; ++e) {
+      auto a = tri.conn[tri_pairs[e][0]];
+      auto b = tri.conn[tri_pairs[e][1]];
+      int sign = (a < b) ? 1 : -1;
+      std::uint64_t key = make_edge_key(a, b);
+      auto it = mesh.edgeIndex.find(key);
+      if (it == mesh.edgeIndex.end()) {
+        int idx = static_cast<int>(mesh.edges.size());
+        mesh.edgeIndex[key] = idx;
+        mesh.edges.push_back(Edge{std::min(a, b), std::max(a, b)});
+        it = mesh.edgeIndex.find(key);
+      }
+      tri.edges[e] = it->second;
+      tri.edge_orient[e] = sign;
+    }
+  }
+}
+} // namespace
 } // namespace vectorem

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(test_edge_indexing test_edge_indexing.cpp)
+target_link_libraries(test_edge_indexing PRIVATE vectorem)
+add_test(NAME test_edge_indexing COMMAND test_edge_indexing)
+set_tests_properties(test_edge_indexing PROPERTIES WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+
+add_executable(test_maxwell test_maxwell.cpp)
+target_link_libraries(test_maxwell PRIVATE vectorem)
+add_test(NAME test_maxwell COMMAND test_maxwell)
+set_tests_properties(test_maxwell PROPERTIES WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})

--- a/tests/test_edge_indexing.cpp
+++ b/tests/test_edge_indexing.cpp
@@ -1,0 +1,34 @@
+#include <cassert>
+#include <array>
+
+#include "vectorem/mesh.hpp"
+
+using namespace vectorem;
+
+int main() {
+  Mesh mesh = load_gmsh_v2("examples/cube_cavity.msh");
+  assert(!mesh.edges.empty());
+  for (size_t i = 0; i < mesh.edges.size(); ++i) {
+    const auto &e = mesh.edges[i];
+    assert(e.n0 < e.n1);
+    auto key = make_edge_key(e.n0, e.n1);
+    assert(mesh.edgeIndex.at(key) == static_cast<int>(i));
+  }
+  const std::array<std::array<int, 2>, 6> tet_pairs = {
+      std::array<int, 2>{0, 1}, std::array<int, 2>{0, 2},
+      std::array<int, 2>{0, 3}, std::array<int, 2>{1, 2},
+      std::array<int, 2>{1, 3}, std::array<int, 2>{2, 3}};
+  for (const auto &tet : mesh.tets) {
+    for (int k = 0; k < 6; ++k) {
+      auto a = tet.conn[tet_pairs[k][0]];
+      auto b = tet.conn[tet_pairs[k][1]];
+      int eid = tet.edges[k];
+      int sign = tet.edge_orient[k];
+      const auto &edge = mesh.edges[eid];
+      assert(edge.n0 == std::min(a, b) && edge.n1 == std::max(a, b));
+      int expected = (a < b) ? 1 : -1;
+      assert(sign == expected);
+    }
+  }
+  return 0;
+}

--- a/tests/test_maxwell.cpp
+++ b/tests/test_maxwell.cpp
@@ -1,0 +1,18 @@
+#include <cassert>
+#include <Eigen/Dense>
+
+#include "vectorem/maxwell.hpp"
+
+using namespace vectorem;
+
+int main() {
+  Mesh mesh = load_gmsh_v2("examples/cube_cavity.msh");
+  BC bc = build_edge_pec(mesh, 1);
+  MaxwellParams p;
+  p.omega = 1.0;
+  auto asmbl = assemble_maxwell(mesh, p, bc);
+  assert(asmbl.A.rows() == static_cast<int>(mesh.edges.size()));
+  Eigen::MatrixXcd A = Eigen::MatrixXcd(asmbl.A);
+  assert(A.isApprox(A.transpose(), 1e-9));
+  return 0;
+}


### PR DESCRIPTION
## Summary
- Introduce global edge indexing and Whitney 1-form basis utilities
- Implement Maxwell curl-curl assembly with PEC boundary support
- Add unit tests for edge connectivity and Maxwell assembly

## Testing
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j`
- `ctest --test-dir build -L smoke -j`
- `ctest --test-dir build -j`

------
https://chatgpt.com/codex/tasks/task_e_6896daf962808325833095f1c1aa1524