### PR TITLE
Add test for Touchstone output header

### DIFF
--- a/tests/test_ports.cpp
+++ b/tests/test_ports.cpp
@@ -1,6 +1,8 @@
 #include <cassert>
 #include <cmath>
 #include <filesystem>
+#include <fstream>
+#include <string>
 
 #include "vectorem/io/touchstone.hpp"
 #include "vectorem/ports/port_eigensolve.hpp"
@@ -31,6 +33,11 @@ int main() {
   std::filesystem::create_directory("out");
   write_touchstone("out/test.s2p", {freq}, {s});
   assert(std::filesystem::exists("out/test.s2p"));
+
+  std::ifstream ifs("out/test.s2p");
+  std::string header;
+  std::getline(ifs, header);
+  assert(header == "# Hz S RI R 50");
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- verify generated Touchstone files include expected header line

## Testing
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j`
- `ctest --test-dir build -L smoke -j`
- `./build/tests/test_ports`


------
https://chatgpt.com/codex/tasks/task_e_68977c3653cc8325a4961c61d175e829