### PR TITLE
Add pyvectorem bindings and Python smoke test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,13 @@ find_package(Eigen3 3.4 REQUIRED)
 
 option(VECTOREM_BUILD_SCALAR "Build scalar prototype" ON)
 option(VECTOREM_BUILD_VECTOR "Build vector Maxwell path" ON)
+option(VECTOREM_PYTHON "Build Python bindings" OFF)
 
 add_subdirectory(src)
 add_subdirectory(tests)
+if (VECTOREM_PYTHON)
+  add_subdirectory(python)
+endif()
 
 if (VECTOREM_BUILD_SCALAR)
   add_test(NAME smoke_scalar_demo COMMAND vectorem_scalar_demo ${PROJECT_SOURCE_DIR}/examples/cube_cavity.msh 1)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,4 @@
+find_package(pybind11 CONFIG REQUIRED)
+pybind11_add_module(pyvectorem pyvectorem.cpp)
+target_link_libraries(pyvectorem PRIVATE vectorem)
+target_include_directories(pyvectorem PRIVATE ${PROJECT_SOURCE_DIR}/include)

--- a/python/pyvectorem.cpp
+++ b/python/pyvectorem.cpp
@@ -1,0 +1,78 @@
+#include <pybind11/complex.h>
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "vectorem/bc.hpp"
+#include "vectorem/fem.hpp"
+#include "vectorem/io/touchstone.hpp"
+#include "vectorem/mesh.hpp"
+#include "vectorem/ports/port_eigensolve.hpp"
+#include "vectorem/solver.hpp"
+
+namespace py = pybind11;
+using namespace vectorem;
+
+PYBIND11_MAKE_OPAQUE(SpMatC);
+PYBIND11_MAKE_OPAQUE(VecC);
+
+PYBIND11_MODULE(pyvectorem, m) {
+  m.doc() = "pybind11 bindings for VectorEM";
+
+  py::class_<Mesh>(m, "Mesh")
+      .def(py::init<>())
+      .def_readonly("nodes", &Mesh::nodes)
+      .def_readonly("tets", &Mesh::tets)
+      .def_readonly("tris", &Mesh::tris);
+
+  m.def("load_gmsh", &load_gmsh_v2, "Load Gmsh v2 mesh");
+
+  py::class_<BC>(m, "BC").def(py::init<>());
+  m.def("build_scalar_pec", &build_scalar_pec, "Build PEC BC", py::arg("mesh"),
+        py::arg("pec_tag"));
+
+  py::class_<ScalarHelmholtzParams>(m, "ScalarHelmholtzParams")
+      .def(py::init<>())
+      .def_readwrite("k0", &ScalarHelmholtzParams::k0)
+      .def_readwrite("eps_r", &ScalarHelmholtzParams::eps_r);
+
+  py::class_<SpMatC>(m, "SpMatC");
+  py::class_<VecC>(m, "VecC");
+
+  py::class_<ScalarAssembly>(m, "ScalarAssembly")
+      .def_property_readonly(
+          "A", [](ScalarAssembly &s) -> SpMatC & { return s.A; },
+          py::return_value_policy::reference_internal)
+      .def_property_readonly(
+          "b", [](ScalarAssembly &s) -> VecC & { return s.b; },
+          py::return_value_policy::reference_internal);
+
+  m.def("assemble_scalar_helmholtz", &assemble_scalar_helmholtz,
+        "Assemble scalar Helmholtz", py::arg("mesh"), py::arg("params"),
+        py::arg("bc"));
+
+  py::class_<SolveOptions>(m, "SolveOptions")
+      .def(py::init<>())
+      .def_readwrite("use_bicgstab", &SolveOptions::use_bicgstab);
+
+  py::class_<SolveResult>(m, "SolveResult")
+      .def_readonly("method", &SolveResult::method)
+      .def_readonly("iters", &SolveResult::iters)
+      .def_readonly("residual", &SolveResult::residual)
+      .def_property_readonly(
+          "x", [](SolveResult &s) -> VecC & { return s.x; },
+          py::return_value_policy::reference_internal);
+
+  m.def("solve_linear", &solve_linear, "Solve linear system", py::arg("A"),
+        py::arg("b"), py::arg("options") = SolveOptions());
+
+  py::class_<SParams2>(m, "SParams2")
+      .def(py::init<>())
+      .def_readwrite("s11", &SParams2::s11)
+      .def_readwrite("s21", &SParams2::s21)
+      .def_readwrite("s12", &SParams2::s12)
+      .def_readwrite("s22", &SParams2::s22);
+
+  m.def("write_touchstone", &write_touchstone, "Write Touchstone file",
+        py::arg("path"), py::arg("freq"), py::arg("data"));
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,8 @@ add_library(vectorem
   mor/vector_fit.cpp
 )
 
+set_target_properties(vectorem PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 if (VECTOREM_BUILD_SCALAR)
   target_sources(vectorem PRIVATE fem_scalar.cpp)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,3 +32,13 @@ add_executable(test_ntf test_ntf.cpp)
 target_link_libraries(test_ntf PRIVATE vectorem)
 add_test(NAME test_ntf COMMAND test_ntf)
 set_tests_properties(test_ntf PROPERTIES WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+
+if (VECTOREM_PYTHON)
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  add_test(NAME python_smoke
+           COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python_smoke.py)
+  set_tests_properties(python_smoke PROPERTIES
+                       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+                       ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/python"
+                       LABELS smoke)
+endif()

--- a/tests/python_smoke.py
+++ b/tests/python_smoke.py
@@ -1,0 +1,10 @@
+import pyvectorem as em
+
+mesh = em.load_gmsh("examples/cube_cavity.msh")
+bc = em.build_scalar_pec(mesh, 1)
+params = em.ScalarHelmholtzParams()
+params.k0 = 1.0
+asm = em.assemble_scalar_helmholtz(mesh, params, bc)
+res = em.solve_linear(asm.A, asm.b, em.SolveOptions())
+em.write_touchstone("smoke.s2p", [1.0], [em.SParams2()])
+print("ok")


### PR DESCRIPTION
## Summary
- add optional `VECTOREM_PYTHON` build with pybind11 bindings for mesh, scalar solver and Touchstone export
- expose bindings in new `pyvectorem` module and basic Python smoke test
- enable PIE for core library and wire smoke test in CTest

## Testing
- `tools/lint.sh build` *(fails: code should be clang-formatted)*
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DVECTOREM_PYTHON=ON -Dpybind11_DIR=$PYBIND11_DIR`
- `cmake --build build -j`
- `ctest --test-dir build -L smoke -j`
- `PYTHONPATH=build/python python -c "import pyvectorem as em; print('ok')"`


------
https://chatgpt.com/codex/tasks/task_e_68978b59e220832584957c280a7ecc49