### PR TITLE
Add skeleton CAD integration package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "vectorem_cad"
+version = "0.1.0"
+description = "CAD import and meshing utilities for VectorEM"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{name = "VectorEM contributors"}]
+dependencies = []
+
+[project.scripts]
+vectorem-cad = "vectorem_cad.cli:main"

--- a/vectorem_cad/__init__.py
+++ b/vectorem_cad/__init__.py
@@ -1,0 +1,48 @@
+"""VectorEM CAD integration package.
+
+This package provides a light‑weight, modular pipeline for importing
+CAD geometry, tagging metadata, generating meshes, previewing results
+and exporting a ready‑to‑simulate VectorEM case.  Only a minimal
+stub implementation is provided here; the public API mirrors the
+intended design so downstream tooling can be developed incrementally."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Optional
+
+
+@dataclass
+class Case:
+    """Container holding intermediate artefacts for a CAD case.
+
+    Parameters
+    ----------
+    geometry : Path | None
+        Path to the original CAD geometry.
+    mesh : Path | None
+        Path to a generated mesh.
+    meta : dict
+        Optional metadata such as material or boundary tags.
+    """
+
+    geometry: Optional[Path] = None
+    mesh: Optional[Path] = None
+    meta: Dict[str, object] = field(default_factory=dict)
+
+
+# Convenience imports for SDK style usage.
+from .io import step_iges, stl_obj  # noqa: F401
+from .mesh.generate import generate_mesh  # noqa: F401
+from .ops.tagging import apply_tags  # noqa: F401
+from .export.vectorem_case import export_case  # noqa: F401
+from .ops.repair import heal_geometry  # noqa: F401
+
+__all__ = [
+    "Case",
+    "apply_tags",
+    "export_case",
+    "generate_mesh",
+    "heal_geometry",
+    "step_iges",
+    "stl_obj",
+]

--- a/vectorem_cad/cli.py
+++ b/vectorem_cad/cli.py
@@ -1,0 +1,85 @@
+"""Command line interface for :mod:`vectorem_cad`.
+
+The CLI is intentionally minimal yet mirrors the proposed commands in
+`system_design_spec.md`.  Each sub‑command delegates to the stub API
+functions defined in this package.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from . import Case
+from .export.vectorem_case import export_case
+from .io import step_iges, stl_obj
+from .mesh.generate import generate_mesh
+from .ops.repair import heal_geometry
+from .ops.tagging import apply_tags
+from .viz.preview import preview
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="vectorem-cad")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_import = sub.add_parser("import", help="Import a CAD file")
+    p_import.add_argument("file", help="Input CAD file")
+    p_import.add_argument("-o", "--out", default="case", help="Output directory")
+
+    p_mesh = sub.add_parser("mesh", help="Generate mesh")
+    p_mesh.add_argument("case_dir")
+
+    p_tag = sub.add_parser("tag", help="Apply tagging")
+    p_tag.add_argument("case_dir")
+
+    p_preview = sub.add_parser("preview", help="Preview geometry or mesh")
+    p_preview.add_argument("case_dir")
+    p_preview.add_argument("--mesh", action="store_true")
+
+    p_export = sub.add_parser("export", help="Export VectorEM case")
+    p_export.add_argument("case_dir")
+    p_export.add_argument("--format", default="vectorem")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.cmd == "import":
+        path = Path(args.file)
+        if path.suffix.lower() in step_iges.SUPPORTED_SUFFIXES:
+            case = step_iges.load_geometry(path)
+        else:
+            case = stl_obj.load_mesh(path)
+        export_case(case, args.out)
+        return 0
+
+    if args.cmd == "mesh":
+        case = Case(geometry=Path(args.case_dir) / "geometry.step")
+        generate_mesh(case)
+        return 0
+
+    if args.cmd == "tag":
+        case = Case()
+        apply_tags(case)
+        return 0
+
+    if args.cmd == "preview":
+        case = Case()
+        preview(case, show_mesh=args.mesh)
+        return 0
+
+    if args.cmd == "export":
+        case = Case(mesh=Path(args.case_dir) / "mesh.msh")
+        export_case(case, args.case_dir)
+        return 0
+
+    parser.error(f"Unknown command {args.cmd}")
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/vectorem_cad/export/vectorem_case.py
+++ b/vectorem_cad/export/vectorem_case.py
@@ -1,0 +1,30 @@
+"""Export a :class:`~vectorem_cad.Case` into a VectorEM case directory."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .. import Case
+
+
+def export_case(case: Case, out_dir: str | Path) -> Path:
+    """Write a minimal VectorEM case structure.
+
+    The function creates ``mesh.msh`` and ``settings.json`` placeholders
+    so that downstream tooling has consistent expectations.
+    """
+
+    dest = Path(out_dir)
+    dest.mkdir(parents=True, exist_ok=True)
+
+    if case.mesh:
+        # In the stub we do not actually copy any mesh data.
+        (dest / "mesh.msh").write_text("0 $MeshFormat\n4.1 0 8\n0\n$EndMeshFormat\n")
+
+    settings = {"notes": "Placeholder case"}
+    (dest / "settings.json").write_text(json.dumps(settings, indent=2))
+    return dest
+
+
+__all__ = ["export_case"]

--- a/vectorem_cad/io/step_iges.py
+++ b/vectorem_cad/io/step_iges.py
@@ -1,0 +1,33 @@
+"""Import STEP and IGES geometry using `pythonocc-core`.
+
+The real implementation would convert BREP data into an internal
+representation.  For now we only record the file path and perform
+basic suffix validation."""
+
+from pathlib import Path
+from .. import Case
+
+SUPPORTED_SUFFIXES = {".step", ".stp", ".iges", ".igs"}
+
+
+def load_geometry(path: str | Path) -> Case:
+    """Load a STEP or IGES file and return a :class:`Case`.
+
+    Parameters
+    ----------
+    path:
+        Location of the CAD file.
+
+    Returns
+    -------
+    Case
+        The newly created case with the geometry path set.
+    """
+
+    file_path = Path(path)
+    if file_path.suffix.lower() not in SUPPORTED_SUFFIXES:
+        raise ValueError(f"Unsupported CAD format: {file_path.suffix}")
+    return Case(geometry=file_path)
+
+
+__all__ = ["load_geometry", "SUPPORTED_SUFFIXES"]

--- a/vectorem_cad/io/stl_obj.py
+++ b/vectorem_cad/io/stl_obj.py
@@ -1,0 +1,21 @@
+"""Import STL and OBJ meshes using :mod:`trimesh` if available."""
+
+from pathlib import Path
+from .. import Case
+
+SUPPORTED_SUFFIXES = {".stl", ".obj"}
+
+
+def load_mesh(path: str | Path) -> Case:
+    """Load a facet mesh and return a :class:`Case` instance.
+
+    This placeholder simply verifies the suffix and records the path.
+    """
+
+    file_path = Path(path)
+    if file_path.suffix.lower() not in SUPPORTED_SUFFIXES:
+        raise ValueError(f"Unsupported mesh format: {file_path.suffix}")
+    return Case(geometry=file_path)
+
+
+__all__ = ["load_mesh", "SUPPORTED_SUFFIXES"]

--- a/vectorem_cad/mesh/generate.py
+++ b/vectorem_cad/mesh/generate.py
@@ -1,0 +1,26 @@
+"""Mesh generation utilities using Gmsh."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .. import Case
+
+
+def generate_mesh(case: Case, element_size: float = 1.0) -> Case:
+    """Generate a tetrahedral mesh using Gmsh.
+
+    This stub merely records a fake mesh file path derived from the
+    geometry.  Real implementations would invoke the Gmsh API and write
+    a ``.msh`` file containing physical groups.
+    """
+
+    if not case.geometry:
+        raise ValueError("Case has no geometry to mesh")
+
+    mesh_path = Path(str(case.geometry) + ".msh")
+    case.mesh = mesh_path
+    return case
+
+
+__all__ = ["generate_mesh"]

--- a/vectorem_cad/ops/repair.py
+++ b/vectorem_cad/ops/repair.py
@@ -1,0 +1,24 @@
+"""Geometry healing and validation operations.
+
+The real project would expose wrappers around OpenCASCADE sewing and
+other algorithms.  For now only a tiny placeholder is provided."""
+
+from .. import Case
+
+
+def heal_geometry(case: Case, tolerance: float = 1e-6) -> Case:
+    """Return the input case after a no‑op "healing" step.
+
+    Parameters
+    ----------
+    case:
+        Case to heal in‑place.
+    tolerance:
+        Healing tolerance; unused in the stub.
+    """
+
+    # A real implementation would modify case.geometry.
+    return case
+
+
+__all__ = ["heal_geometry"]

--- a/vectorem_cad/ops/tagging.py
+++ b/vectorem_cad/ops/tagging.py
@@ -1,0 +1,23 @@
+"""Mapping CAD attributes to simulation tags."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .. import Case
+
+
+def apply_tags(case: Case, sidecar: str | Path | None = None) -> Case:
+    """Populate :attr:`Case.meta` with tags.
+
+    The implementation here is intentionally tiny: if ``sidecar`` is
+    provided, the function records its path.  Real parsing of STEP
+    attributes or YAML is left for future work.
+    """
+
+    if sidecar:
+        case.meta.setdefault("sidecar", Path(sidecar))
+    return case
+
+
+__all__ = ["apply_tags"]

--- a/vectorem_cad/sdk/__init__.py
+++ b/vectorem_cad/sdk/__init__.py
@@ -1,0 +1,16 @@
+"""Public SDK convenience layer.
+
+This module re-exports the high level functions so that users can write
+``from vectorem_cad.sdk import import_cad`` etc.  The goal is to keep the
+public surface tiny and stable."""
+
+from .. import Case, apply_tags, export_case, generate_mesh
+from ..io.step_iges import load_geometry as import_cad
+
+__all__ = [
+    "Case",
+    "apply_tags",
+    "export_case",
+    "generate_mesh",
+    "import_cad",
+]

--- a/vectorem_cad/viz/preview.py
+++ b/vectorem_cad/viz/preview.py
@@ -1,0 +1,23 @@
+"""Visualization helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .. import Case
+
+
+def preview(case: Case, show_mesh: bool = False) -> Path:
+    """Return a path to a dummy screenshot for tests.
+
+    The actual project would use :mod:`pyvista` or ``gmsh`` for
+    interactive viewing.  Here we just create an empty PNG file to
+    simulate an exported screenshot.
+    """
+
+    screenshot = Path("preview.png")
+    screenshot.write_bytes(b"")
+    return screenshot
+
+
+__all__ = ["preview"]


### PR DESCRIPTION
## Summary
- scaffold `vectorem_cad` package for CAD import, tagging, meshing, and case export
- provide minimal CLI with subcommands for import, mesh, tagging, preview, and export
- include pyproject entry point for `vectorem-cad`

## Testing
- `pytest -q`
- `python -m vectorem_cad.cli --help`


------
https://chatgpt.com/codex/tasks/task_e_689819e078f08325b5d50df85c24b45e